### PR TITLE
Fix various problems with new results

### DIFF
--- a/libraries/numpy/library.json
+++ b/libraries/numpy/library.json
@@ -1,6 +1,6 @@
 {
     "name": "numpy",
     "ghurl": "https://github.com/numpy/numpy",
-    "baseversion": "v1.22.3",
-    "currentversion": "v1.24.2"
+    "baseversion": "v1.24",
+    "currentversion": "v2.0"
 }

--- a/libraries/pandas/requirements.txt
+++ b/libraries/pandas/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl
+numpy==1.26.4

--- a/src/upgraider/Model.py
+++ b/src/upgraider/Model.py
@@ -142,6 +142,18 @@ def find_references_in_response(model_response: str) -> str:
     return references
 
 
+def _is_no_update(model_response: str) -> bool:
+    no_update_keywords = ["No update", "does not need to be updated"]
+
+    if any(keyword in model_response for keyword in no_update_keywords):
+        return True
+
+    if model_response == "No references used":
+        return True
+
+    return False
+
+
 def parse_model_response(model_response: str) -> ModelResponse:
 
     # match the updated code by looking for the fenced code block, even without the correct enumeration
@@ -155,10 +167,7 @@ def parse_model_response(model_response: str) -> ModelResponse:
         else:
             update_status = UpdateStatus.NO_UPDATE
     else:
-        if (
-            "No update" in model_response
-            or "does not need to be updated" in model_response
-        ):
+        if _is_no_update(model_response):
             update_status = UpdateStatus.NO_UPDATE
         else:
             update_status = UpdateStatus.NO_RESPONSE

--- a/src/upgraider/Model.py
+++ b/src/upgraider/Model.py
@@ -39,8 +39,6 @@ class Model:
             messages=prompt, model=self.model_name, **LLM_API_PARAMS
         )
 
-        print("response: ", response)
-
         result = response["choices"][0]["message"]["content"]
 
         return result

--- a/src/upgraider/upgraide.py
+++ b/src/upgraider/upgraide.py
@@ -39,9 +39,8 @@ class Upgraider:
 
         model_response = self.model.query(prompt_text)
 
-        parsed_model_response = parse_model_response(model_response)
+        parsed_model_response = parse_model_response(model_response, code_snippet)
         parsed_model_response.prompt = prompt_text
-        parsed_model_response.original_code = code_snippet
         parsed_model_response.library = library
 
         if parsed_model_response.update_status == UpdateStatus.UPDATE:

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,9 +1,33 @@
 from upgraider.Model import UpdateStatus, parse_model_response
+from apiexploration.Library import CodeSnippet
+
+
+def test_providedcode_noupdate():
+    original_code = """
+import numpy as np
+from scipy.optimize import minimize
+
+def rosen(x):
+    return sum(100.0*(x[1:]-x[:-1]**2.0)**2.0 + (1-x[:-1])**2.0)
+"""
+    response = f"""
+1. 
+```python
+{original_code}
+```
+
+2. No updates needed.
+3. No references used
+    """
+
+    result = parse_model_response(response, CodeSnippet(code=original_code))
+    assert result.update_status == UpdateStatus.NO_UPDATE
 
 
 def test_noreferences_response():
     response = """No references used"""
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.NO_UPDATE
 
 
@@ -26,7 +50,8 @@ print(dense_cat)
 3. {reference}
     """
 
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.UPDATE
     assert result.references == reference
     assert result.updated_code.code == updated_code.strip()
@@ -40,7 +65,8 @@ def test_incorrect_short_repsonse():
 {reference}
     """
 
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.NO_RESPONSE
 
 
@@ -50,7 +76,8 @@ def test_incorrect_long_repsonse():
 Reason: The code is using valid and up-to-date numpy APIs to create an array and sort it. No deprecated or non-existent APIs are being used.
 References used: No references used.
 """
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
 
     assert result.update_status == UpdateStatus.NO_UPDATE
     assert result.references is None
@@ -71,7 +98,8 @@ Reason for update: {reason}
 List of reference numbers used: {references}
 """
 
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.UPDATE
     assert result.reason == reason
     assert result.references == references
@@ -90,7 +118,8 @@ some code
 2. {reason}
 3. {reference}
 """
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.UPDATE
     assert result.reason == reason
     assert result.references == reference
@@ -105,7 +134,8 @@ some code
 - Reason for update: None
 - List of reference numbers used: No references used
 """
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.UPDATE
     assert result.reason is None
     assert result.references is None
@@ -124,7 +154,8 @@ some code
 - Reason for update: None
 - List of reference numbers used: No references used
 """
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.NO_UPDATE
     assert result.reason is None
     assert result.references is None
@@ -147,6 +178,7 @@ List of reference numbers used:
 
 - 6
 """
-    result = parse_model_response(response)
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
     assert result.update_status == UpdateStatus.UPDATE
     assert result.reason == f"- {reason1}\n- {reason2}"

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,6 +1,12 @@
 from upgraider.Model import UpdateStatus, parse_model_response
 
 
+def test_noreferences_response():
+    response = """No references used"""
+    result = parse_model_response(response)
+    assert result.update_status == UpdateStatus.NO_UPDATE
+
+
 def test_correctly_formatted_response():
     reference = "32639"
     updated_code = """

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -2,6 +2,27 @@ from upgraider.Model import UpdateStatus, parse_model_response
 from apiexploration.Library import CodeSnippet
 
 
+def test_extra_code_fencing():
+    updated_code = """
+G = nx.from_numpy_array(A)
+print(G.edges)
+"""
+    response = f"""
+1. ```The full updated code snippet in a fenced code block```
+```python
+{updated_code}
+```
+
+2. Some explation
+
+3. No references used
+"""
+    original_code = """originalcode()"""
+    result = parse_model_response(response, CodeSnippet(code=original_code))
+    assert result.update_status == UpdateStatus.UPDATE
+    assert result.updated_code.code.strip() == updated_code.strip()
+
+
 def test_providedcode_noupdate():
     original_code = """
 import numpy as np


### PR DESCRIPTION
This PR will address the various results problems described in Issue #6 

1. fixed numpy base version to see deprecation warnings on examples
2. Handle multiple code snippets in a response (through heuristics on length of snippets etc)
3. Fix the numpy version the pandas examples depend on to remove the persistent ValueError on all pandas examples
4. Correctly identify NO_UPDATE (As opposed to marking it as NO_RESPONSE)
5. Compare code snippet in response to original code snippet to check if it has been updated or if it's the same one